### PR TITLE
feat: staple and zip macOS binary

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -44,8 +44,8 @@ jobs:
         run: |
           pyinstaller -m wiki_extractor.cli --name wiki-extractor --onefile
 
-      # ---------- macOS: sign single-file with LV entitlement, ZIP-notarize (no stapling) ----------
-      - name: Sign & Notarize macOS single-file (ZIP; no stapling)
+      # ---------- macOS: sign single-file with LV entitlement, notarize, staple and zip ----------
+      - name: Sign, Notarize, Staple & ZIP macOS single-file
         if: runner.os == 'macOS'
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}                 # base64-encoded .p12 (Developer ID Application + private key)
@@ -108,12 +108,17 @@ jobs:
           # ZIP the single file for notarization (Apple scans the binary inside)
           /usr/bin/zip -q -j "$ZIP_FILE" "$OUT_FILE"
 
-          # Notarize and wait for the result (no stapling for raw executables)
+          # Notarize and wait for the result
           xcrun notarytool submit "$ZIP_FILE" \
             --apple-id "$APPLE_DEVELOPER_ID" \
             --password "$APPLE_APP_SPECIFIC_PASSWORD" \
             --team-id "$APPLE_TEAM_ID" \
             --wait
+
+          # Staple the ticket and re-ZIP the binary for release
+          xcrun stapler staple "$OUT_FILE"
+          rm -f "$ZIP_FILE"
+          /usr/bin/zip -q -j "$ZIP_FILE" "$OUT_FILE"
 
           # Cleanup secrets/materials
           security delete-keychain "$KEYCHAIN_PATH"
@@ -129,11 +134,11 @@ jobs:
         run: mv dist/wiki-extractor.exe dist/wiki-extractor-windows-x86_64.exe
 
       # ---------- Upload per-OS artifacts ----------
-      - name: Upload macOS single-file
+      - name: Upload macOS zip
         if: runner.os == 'macOS'
         uses: softprops/action-gh-release@v1
         with:
-          files: dist/wiki-extractor-macos-${{ matrix.arch }}
+          files: dist/wiki-extractor-macos-${{ matrix.arch }}.zip
 
       - name: Upload Linux artifact
         if: runner.os == 'Linux'

--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ python -m wiki_extractor "https://en.wikipedia.org/wiki/Homer" --tts -o output
 Release builds include standalone executables for Windows, macOS and
 Linux created with PyInstaller. Download the file for your platform from
 the [releases page](https://github.com/patrickdeanbrown/wiki_extractor/releases),
-make it executable if necessary (`chmod +x wiki-extractor` on
-Unix-like systems) and run it directly:
+unzip it if needed, move `wiki-extractor` into a directory on your `PATH`
+(for example `/usr/local/bin`), make it executable if necessary
+(`chmod +x wiki-extractor` on Unix-like systems) and run it directly:
 
 ```bash
 ./wiki-extractor "Homer" --tts --heading-prefix "Section:" -o output


### PR DESCRIPTION
## Summary
- staple notarized macOS binary and re-zip for distribution
- upload macOS `.zip` in release workflow
- document unzipping and moving to PATH in README

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab44c1d774832f9d487be24a2f027c